### PR TITLE
Exercise 3.2 Fixed wrong feature count

### DIFF
--- a/ex3/Ex3_2.ipynb
+++ b/ex3/Ex3_2.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "X_train = pd.read_table('./HAPT Data Set/Train/X_train.txt',\n",
-    "             header = None, sep = \" \", names = list(dict.fromkeys(features)))\n",
+    "             header = None, sep = \" \")\n",
     "X_train.iloc[:10, :10].head()"
    ]
   },
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "X_test = pd.read_table('./HAPT Data Set/Test/X_test.txt',\n",
-    "             header = None, sep = \" \", names = list(dict.fromkeys(features)))\n",
+    "             header = None, sep = \" \")\n",
     "y_test = pd.read_table('./HAPT Data Set/Test/y_test.txt',\n",
     "             header = None, sep = \" \", names = ['Activity_id'])"
    ]


### PR DESCRIPTION
In exercise 3.2 X_train and X_test had the wrong feature count, because of the usage of sets. 
Removing this fixed the count from 533 to the correct 561.