### PR TITLE
[ex2] add explanations on MFCC

### DIFF
--- a/ex2/task/MLonMCU_Ex2.ipynb
+++ b/ex2/task/MLonMCU_Ex2.ipynb
@@ -383,7 +383,14 @@
     "We can perform *feature extraction* to reduce the amount of data to process next. \n",
     "\n",
     "To do so, let's extract the MFCCs for this audio; using the default parameters of librosa's function, we will end up with 20 MFCCs per audio's frame. \n",
-    "*librosa* will take care of the division in frames, analysis and MFCCs extraction."
+    "*librosa* will take care of the division in frames, analysis and MFCCs extraction.\n",
+    "\n",
+    "> Notes on MFCCs extraction:\n",
+    "> - The original audio signal is divided into overlapping frames, and for each frame, a set of MFCCs is computed.\n",
+    "> - MFCCs are a compact representation of the short-term spectral envelope of a sound. MFCCs of one audio's frame are a vector of coefficients that describe the spectral features of a short segment of audio (audio frame).\n",
+    "> - MFCCs are derived from the Mel scale, which is a perceptual scale of pitches that approximates the human ear's response to different frequencies.\n",
+    "> - The Mel scale is designed to be more sensitive to lower frequencies and less sensitive to higher frequencies, which aligns with how humans perceive sound.\n",
+    "> - MFCCs are widely used in various audio processing tasks, including speech recognition, music information retrieval..."
    ]
   },
   {
@@ -444,6 +451,19 @@
     "plt.colorbar()\n",
     "plt.title('MFCC')\n",
     "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This MFCC visualization shows how the MFCCs (cepstral coefficients) vary over time (frames). MFCCs on the bottom generally represent lower frequencies features (spectral shape), while those on the top represent higher frequencies features.\n",
+    "\n",
+    "Go back to the audio signal: can you see how the MFCCs change when the audio signal amplitude changes? \n",
+    "1. Within each frame: Dark blue and dark red areas in the MFCC plot correspond to strong presence of certain frequency components in the audio signal, which is prominently visible in the bottom part of the MFCC plot. This gives us a hint that the original audio signal is dominated by low tones. \n",
+    "2. Across frames: We can see rapid changes in the audio signal, which is reflected in the MFCC plot as sharp change of color instead of smooth transitions. This gives a hint that the original audio signal has fast attacks.\n",
+    "\n",
+    "MFCC extraction helps us to capture the essential spectral characteristics of the audio signal while reducing the amount of data we need to process. This is particularly useful in machine learning applications where we want to analyze and classify audio signals efficiently."
    ]
   },
   {


### PR DESCRIPTION
-  The most confusing concepts appears during the execution of `librosa.feature.mfcc()`, so I add additional explanations like *frame* there. 
- Based on the MFCC visualization of example audio, I add some insights based on MFCC features and the relationship to original audio file.

If there are any logical problem or inaccuracy in my explanations, additional modifications can be made. 